### PR TITLE
ナビバーの検索フォームの削除

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,9 +9,5 @@
         <a><%= link_to "　投稿画面　", new_racket_path %></a>
       </li>
     </ul>
-    <form class="form-inline my-2 my-lg-0">
-      <input class="form-control mr-sm-2" type="search" placeholder="キーワード" aria-label="Search">
-      <button class="btn btn-outline-success my-2 my-sm-0" type="submit">検索</button>
-    </form>
   </div>
 </nav>


### PR DESCRIPTION
## 目的
ナビバーの検索フォームを使えるような実装方法が思いつかなかったので、表示しないように削除する。

## やったこと
- _header.html.erbから検索フォームとボタンの記述を削除