### PR TITLE
検索フォームの実装と、それに合わせたラケット一覧画面(index)の設定変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'carrierwave'
 gem 'rmagick'
 gem 'bootstrap', '~> 4.1.1'
 gem 'jquery-rails'
+gem 'ransack'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,11 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (12.3.2)
+    ransack (2.1.1)
+      actionpack (>= 5.0)
+      activerecord (>= 5.0)
+      activesupport (>= 5.0)
+      i18n
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -226,6 +231,7 @@ DEPENDENCIES
   mysql2 (>= 0.4.4, < 0.6.0)
   puma (~> 3.11)
   rails (~> 5.2.2)
+  ransack
   rmagick
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/controllers/rackets_controller.rb
+++ b/app/controllers/rackets_controller.rb
@@ -1,6 +1,7 @@
 class RacketsController < ApplicationController
   def index
-    @rackets = Racket.all
+    racket = Racket.new(params_racket_search)
+    @rackets = racket.search
   end
 
   def new
@@ -32,5 +33,9 @@ class RacketsController < ApplicationController
   private
     def racket_params
       params.require(:racket).permit(:name, :price, :kind, :image, :remove_image)
+    end
+
+    def params_racket_search
+      params.permit(:search_name, :search_price, :search_kind, :search_image)
     end
 end

--- a/app/models/racket.rb
+++ b/app/models/racket.rb
@@ -1,3 +1,9 @@
 class Racket < ApplicationRecord
   mount_uploader :image, ImageUploader
+
+  attr_accessor :search_name, :search_price, :search_kind, :search_image
+
+  def search
+    Racket.ransack(name_cont: @search_name, kind_cont: @search_kind).result
+  end
 end

--- a/app/views/rackets/index.html.erb
+++ b/app/views/rackets/index.html.erb
@@ -1,3 +1,11 @@
+<%= form_tag(root_path, method: :get) do %>
+  <%= label_tag :名前 %>
+  <%= text_field_tag :search_name %>
+  <%= label_tag :種類 %>
+  <%= text_field_tag :search_kind %>
+  <%= submit_tag '検索' %>
+<% end %>
+
 <% @rackets.each do |racket| %>
   <p>
     <%= image_tag racket.image_url(:thumb).to_s %>


### PR DESCRIPTION
## 目的
検索フォームの実装と、ラケット一覧画面を検索した際に検索結果を反映できるようにする。

## やったこと
- ransackというgemを追加
- racketモデルにsearchメソッドを追加
- racketコントローラのindexアクションの修正(前のRacket.allは削除)
- racket.index.html.erbの修正
- searchメソッドで、名前と種類の検索条件をeq → cont(完全一致から部分一致)に修正

## 気をつけたこと
- racketコントローラのindexアクションの修正
　いかに今までの記述を崩さずそのまま利用するための方法を再考
　　@racketsの変数をそのまま利用して、検索結果が反映されるよう設定

