### PR TITLE
管理画面の日本語化の追加

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,3 +11,8 @@ ja:
         image: '画像'
         created_at: '作成日時'
         updated_at: '更新日時'
+      admin_user:
+        email: 'メールアドレス'
+        password: 'パスワード'
+        password_confirmation: 'パスワードの確認'
+        created_at: '作成日時'


### PR DESCRIPTION
## 目的
管理画面の管理者のラベルを日本語化にして、見やすくするため。

## やったこと
- config/locales/fa.ymlで管理者画面を日本語化するコードを追加