### PR TITLE
管理画面の日本語化の追加

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       racket: 'ラケット'
       admin_user: '管理者'
+      comment: 'コメント'
     attributes:
       racket:
         name: '名前'


### PR DESCRIPTION
## 目的
管理画面のcommentが日本語化されていなかったので、日本語化する。

## やったこと
- config/locales/ja.ymlにcommentの日本語化対応のコードを追加