### PR TITLE
S3の設定から最初の状態に戻して、本番環境のアプリを復活させる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'activeadmin'
 gem 'devise'
 gem 'rails-i18n'
 gem 'aws-sdk-s3', require: false
+gem 'fog-aws'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,8 +123,26 @@ GEM
       responders
       warden (~> 1.2.3)
     erubi (1.8.0)
+    excon (0.62.0)
     execjs (2.7.0)
     ffi (1.10.0)
+    fog-aws (3.4.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.1.2)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
@@ -142,6 +160,7 @@ GEM
       railties (>= 4.2, < 5.3)
       responders
     io-like (0.3.0)
+    ipaddress (0.8.3)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -300,6 +319,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  fog-aws
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,6 +1,6 @@
 class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::RMagick
-  storage :file
+  storage :fog
   process convert: 'jpg'
   # 保存するディレクトリ名
   def store_dir

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,9 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :amazon
+  # config.active_storage.service = :amazon
+  config.active_storage.service = :local
+
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
## 目的
S3の設定を最初の状態
(amazom → local)に戻して、herokuのApplication Errorを解消してアプリを復活させる。

## やったこと
- config/environments/production.rbにあるconfig.active_storage.service = :amazonをコメントアウト
- 代わりに、config.active_storage.service = :localを復活させる。