### PR TITLE
git push heroku master時のエラー解消

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,3 +10,5 @@ module OriginalApp1
     config.i18n.default_locale = :ja
   end
 end
+
+config.assets.initialize_on_precompile = false


### PR DESCRIPTION
## 目的
git push heroku masterしたら、Precompiling assets failedというエラーでrejectされたので、それを解消してherokuにpushできるようにする。

## やったこと
- config/application.rbに config.assets.initialize_on_precompile = false を追加