### PR TITLE
config/applicationの不要なコードの削除

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,5 +10,3 @@ module OriginalApp1
     config.i18n.default_locale = :ja
   end
 end
-
-config.assets.initialize_on_precompile = false


### PR DESCRIPTION
## 目的
git push heroku master時にconfigのメソッドエラーが出たので、その対象となる箇所を削除してherokuにpushできるようにする。

## やったこと
- config/applicationの14行目のconfig~のコードを削除
