### PR TITLE
herokuに無事pushできるように、Precompiling assets failed.のheroku pushエラーに対応する。

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,5 +8,6 @@ module OriginalApp1
   class Application < Rails::Application
     config.load_defaults 5.2
     config.i18n.default_locale = :ja
+    config.assets.initialize_on_precompile = false
   end
 end


### PR DESCRIPTION
## 目的
同上。

## やったこと
- config/applicationのmoduleのclass~endの間にconfig.assets.initialize_on_precompile = falseを追加