### PR TITLE
gemの削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'activeadmin'
 gem 'devise'
 gem 'rails-i18n'
 gem 'aws-sdk-s3', require: false
-gem 'fog'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,6 +1,6 @@
 class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::RMagick
-  storage :fog
+  storage :file
   process convert: 'jpg'
   # 保存するディレクトリ名
   def store_dir


### PR DESCRIPTION
## 目的
fogというgemを削除し、ファイル関係のエラー(Precompiling assets failed)を解消してherokuにpushできるようにする。

## やったこと
- image_uploaderのstorageをfogからfileに変更
- gemのfogを削除