### PR TITLE
ページネーション機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem 'activeadmin'
 gem 'devise'
 gem 'rails-i18n'
 gem 'aws-sdk-s3', require: false
+gem 'kaminari'
+gem 'kaminari-bootstrap', '~> 3.0.1'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,9 @@ GEM
     kaminari-activerecord (1.1.1)
       activerecord
       kaminari-core (= 1.1.1)
+    kaminari-bootstrap (3.0.1)
+      kaminari (>= 0.13.0)
+      rails
     kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -302,6 +305,8 @@ DEPENDENCIES
   devise
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
+  kaminari-bootstrap (~> 3.0.1)
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
   puma (~> 3.11)

--- a/app/controllers/rackets_controller.rb
+++ b/app/controllers/rackets_controller.rb
@@ -2,6 +2,7 @@ class RacketsController < ApplicationController
   def index
     racket = Racket.new(params_racket_search)
     @rackets = racket.search
+    @rackets = @rackets.order(:name).page params[:page]
   end
 
   def new

--- a/app/views/rackets/index.html.erb
+++ b/app/views/rackets/index.html.erb
@@ -18,3 +18,5 @@
     <%= link_to "編集", edit_racket_path(racket) %>
   </p>
 <% end %>
+
+<%= paginate @rackets %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Kaminari.configure do |config|
+  config.default_per_page = 3
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "最初"
+      last: "最後"
+      previous: "前"
+      next: "次"
+      truncate: "..."


### PR DESCRIPTION
## 目的
同上。

## やったこと
- kaminariというgem
- kaminari_config.rbを作成し、ページ最大表示項目数を3に設定
- racketsコントローラのindexアクションに、ページネーション用のアクションを追加
　→ここで既存の検索機能のアクションと共存するためにはどうすれば良いか悩む
　　→検索結果のデータを格納する変数をページネーションの対象としていなかったことが判明
　　　→@rackets = @rackets(検索機能のデータを格納する変数)~ と記述して実装が完了
- indexビューにpagenate @racketsを追加
- kaminari-bootstrapというgemを追加
- config/locales/kaminari_ja.ymlを追加し、i18nの設定を追加

### 参考URL
- kaminariの公式
https://github.com/kaminari/kaminari

- kaminariでのページネーション機能の実装について
https://qiita.com/residenti/items/1ae1e5ceb59c0729c0b9
https://qiita.com/you8/items/df68aaee3010e282d1ae
https://www.yuta-u.com/programing/rails/rails-kaminari
https://note.mu/hajime38/n/n897c6ff4af04

- 既存の検索機能と共存させるためのヒント
https://teratail.com/questions/129431