### PR TITLE
racketsコントローラ内で重複している処理をprivateメソッドにしてbefore_actionに設定

### DIFF
--- a/app/controllers/rackets_controller.rb
+++ b/app/controllers/rackets_controller.rb
@@ -1,9 +1,13 @@
 class RacketsController < ApplicationController
+  before_action :set_racket, only: [:destroy, :edit, :update, :show]
+
   def index
     racket = Racket.new(params_racket_search)
     @rackets = racket.search
     @rackets = @rackets.order(:name).page params[:page]
   end
+
+# before_actionにより、destroy, edit, update, showメソッドでは、@racket = Racket.find(params[:id])の記述はいらなくなる。
 
   def new
     @racket = Racket.new
@@ -14,21 +18,17 @@ class RacketsController < ApplicationController
   end
 
   def destroy
-    racket = Racket.find(params[:id])
-    racket.destroy
+    @racket.destroy
   end
 
   def edit
-    @racket = Racket.find(params[:id])
   end
 
   def update
-    racket = Racket.find(params[:id])
-    racket.update(racket_params)
+    @racket.update(racket_params)
   end
 
   def show
-    @racket = Racket.find(params[:id])
   end
 
   private
@@ -38,5 +38,9 @@ class RacketsController < ApplicationController
 
     def params_racket_search
       params.permit(:search_name, :search_price, :search_kind, :search_image)
+    end
+
+    def set_racket
+      @racket = Racket.find(params[:id])
     end
 end


### PR DESCRIPTION
## 目的
同じ処理の重複を避けることで将来アクションを増やした時に、変更があるたびに同じ箇所を修正するという手間をなくすため。

## やったこと
- racketsコントローラ内の@racket = Racket.find(params[:id])という記述をprivateメソッドにする
- 上記のset_racketメソッドを、destroy, edit, update, showメソッドのみbefore_actionで設定