### PR TITLE
送信ボタンの表示の変更

### DIFF
--- a/app/views/rackets/edit.html.erb
+++ b/app/views/rackets/edit.html.erb
@@ -23,5 +23,5 @@
       </script>
       <%= image_tag @racket.image_url(:thumb).to_s, id: :image_prev if @racket.image? %>
       <p><%= f.check_box :remove_image %>現在の画像を削除する</p>
-    <input type="submit" value="送信">
+    <input type="submit" value="更新する">
   <% end %>

--- a/app/views/rackets/new.html.erb
+++ b/app/views/rackets/new.html.erb
@@ -6,7 +6,7 @@
       <div class="mb-2">値段:<%= f.text_field :price %></div>
       <div class="mb-2">種類:<%= f.text_field :kind %></div>
       <div class="mb-2">画像:<%= f.file_field :image %></div>
-    <input type="submit" value="送信">
+    <input type="submit" value="投稿する">
   <% end %>
 <% else %>
   <div>新規投稿は、ログインするとできます</div>


### PR DESCRIPTION
## 目的
入力した情報をすべて「送信」だとわかりづらいので、それぞれのページに合った表示に変更してわかりやすくする。

## やったこと
- racketのedit(編集画面)の送信ボタンを「更新する」という表示に変更
- racketのnew(投稿画面)の送信ボタンを「投稿する」という表示に変更