### PR TITLE
投稿画面のエラーメッセージの表示を修正

### DIFF
--- a/app/views/rackets/new.html.erb
+++ b/app/views/rackets/new.html.erb
@@ -1,7 +1,13 @@
 <% if @racket.errors.any? %>
+  <h2>
+    <font color="red">※入力エラーです</font>
+  </h2>
   <% @racket.errors.full_messages.each do |message| %>
-    <p>※入力エラー</p>
-    <p><%= message %></p>
+    <ul>
+      <li>
+        <font color="red"><%= message %></font>
+      </li>
+    </ul>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
## 目的
入力エラーがあったときに、そのエラー内容が投稿者にわかりやすくするため。

## やったこと
- racket/new.html.erbに、赤色で各エラーメッセージが箇条書きで表示されるように修正