### PR TITLE
ログイン画面の表示を日本語化

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,25 +1,25 @@
-<h2>Log in</h2>
+<h2>ログイン</h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label "メールアドレス" %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
+    <%= f.label "パスワード" %><br />
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 
   <% if devise_mapping.rememberable? %>
     <div class="field">
       <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+      <%= f.label "ログイン情報を記録する" %>
     </div>
   <% end %>
 
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "ログインする" %>
   </div>
 <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,13 +1,13 @@
-<%- if controller_name != 'sessions' %>
+<!-- <%- if controller_name != 'sessions' %>
   <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end %>
+<% end %> -->
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+<!-- <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
   <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
+<% end %> -->
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "パスワードをお忘れの方はこちら", new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>


### PR DESCRIPTION
## 目的
他のページと同様の表示にすることで、サイト内を統一化してユーザーが混乱しないようにするため。

## やったこと
- devise/sessions/htmlを修正
- log_inとsign_upはナビバーに設定されているので、ページ下部にあったリンク先が表示されないように、_link.htmlの該当箇所をコメントアウト化