### PR TITLE
パスワードの再発行画面の日本語化

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,15 +1,15 @@
-<h2>Forgot your password?</h2>
+<h2>パスワードの再発行</h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label "メールアドレス" %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+    <%= f.submit "パスワードを再発行する" %>
   </div>
 <% end %>
 


### PR DESCRIPTION
## 目的
他のページと同様の表示にすることで、サイト内を統一してユーザーの混乱を防ぐため。

## やったこと
- devise/password.htmlを修正