### PR TITLE
ナビバーの「プロフィール変更」を「アカウント設定」に変更

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2>プロフィール変更</h2>
+<h2>アカウント設定</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,7 +16,7 @@
           <div class="nav-link"></div> <%= link_to "マイページ", user_path(current_user.id) %>
         </li>
         <li class="nav-item active">
-          <div class="nav-link"></div> <%= link_to "プロフィール変更", edit_user_registration_path %>
+          <div class="nav-link"></div> <%= link_to "アカウント設定", edit_user_registration_path %>
         </li>
       <% else %>
         <li class="nav-item active">


### PR DESCRIPTION
## 目的
アカウント設定画面（旧プロフィール変更画面）の下部に表示している、「現在のアカウントを削除する」というボタン表記に合わせて、「アカウント設定」と表記した方がしっくりくるから。
※「プロフィールを削除する」という表記には若干の違和感があった。

## やったこと
- views/devise/registrations/edit と layouts/_header の「プロフィール変更」を「アカウント設定」という表記に変更