### PR TITLE
不要なコメントアウトを削除

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -17,7 +17,6 @@
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>
       <br />
-      <!-- <em>(最低 <%= @minimum_password_length %> 文字以上を入力してください)</em> -->
     <% end %>
   </div>
 


### PR DESCRIPTION
## 目的
余計なコードを減らして見やすくするため。

## やったこと
- views/devise/registrations/edit.html.erbの不要なコメントアウトを1行削除